### PR TITLE
feat: make network zone and groups a dynamic lookup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ test-plan:
 	terraform plan -var-file=test.tfvars
 
 test-apply:
-	terraform apply -var-file=test.tfvars -autoapprove
+	terraform apply -var-file=test.tfvars -auto-approve
 
 docs:
 	poetry run python make_doc.py

--- a/README.md
+++ b/README.md
@@ -10,17 +10,17 @@ The module expects a yaml file with the following structure:
 | `description` | `<class 'str'>`     | `True`     |           | Description of the policy |
 | `rules`       | `list[schema.Rule]` | `True`     |           | List of configured rules  |
 ## Rule
-| name               | type                                                                                             | required   | default   | description                                                                            |
-|--------------------|--------------------------------------------------------------------------------------------------|------------|-----------|----------------------------------------------------------------------------------------|
-| `name`             | `<class 'str'>`                                                                                  | `True`     |           | Name of the rule                                                                       |
-| `access`           | `typing.Literal['ALLOW', 'DENY']`                                                                | `True`     |           | Access type.                                                                           |
-| `network_zones`    | `typing.Optional[list[str]]`                                                                     | `False`    |           | List of network zone IDs.                                                              |
-| `step_up_auth`     | `typing.Optional[bool]`                                                                          | `False`    |           | Whether or not MFA is required each auth.                                              |
-| `auth_frequency`   | `typing.Optional[typing.Literal['daily', 'hourly']]`                                             | `False`    |           | Frequency of auth.                                                                     |
-| `group_targets`    | `typing.Optional[list[str]]`                                                                     | `False`    |           | Groups to target for the policy rule.                                                  |
-| `group_exclusions` | `typing.Optional[list[str]]`                                                                     | `False`    |           | Groups to exclude for the policy rule.                                                 |
-| `managed_device`   | `typing.Optional[list[typing.Literal['all', 'ios', 'macos', 'android', 'windows', 'chromeos']]]` | `False`    |           | Managed devices to target for the policy rule.  Cannot be set with `unmanaged_device`. |
-| `unmanaged_device` | `typing.Optional[list[typing.Literal['all', 'ios', 'macos', 'android', 'windows', 'chromeos']]]` | `False`    |           | Unmanaged devices to target for the policy rule.  Cannot be set with `managed_device`. |
+| name               | type                                                                                             | required   | default   | description                                                                                                                                |
+|--------------------|--------------------------------------------------------------------------------------------------|------------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| `name`             | `<class 'str'>`                                                                                  | `True`     |           | Name of the rule                                                                                                                           |
+| `access`           | `typing.Literal['ALLOW', 'DENY']`                                                                | `True`     |           | Access type.                                                                                                                               |
+| `network_zones`    | `typing.Optional[list[str]]`                                                                     | `False`    |           | List of network zone names.  These must exist.  Consider using `depends_on` in your module declaration on required network zones.          |
+| `step_up_auth`     | `typing.Optional[bool]`                                                                          | `False`    |           | Whether or not MFA is required each auth.                                                                                                  |
+| `auth_frequency`   | `typing.Optional[typing.Literal['daily', 'hourly']]`                                             | `False`    |           | Frequency of auth.                                                                                                                         |
+| `group_targets`    | `typing.Optional[list[str]]`                                                                     | `False`    |           | Group names to target for the policy rule.  These must exist.  Consider using `depends_on` in your module declaration on required groups.  |
+| `group_exclusions` | `typing.Optional[list[str]]`                                                                     | `False`    |           | Group names to exclude for the policy rule.  These must exist.  Consider using `depends_on` in your module declaration on required groups. |
+| `managed_device`   | `typing.Optional[list[typing.Literal['all', 'ios', 'macos', 'android', 'windows', 'chromeos']]]` | `False`    |           | Managed devices to target for the policy rule.  Cannot be set with `unmanaged_device`.                                                     |
+| `unmanaged_device` | `typing.Optional[list[typing.Literal['all', 'ios', 'macos', 'android', 'windows', 'chromeos']]]` | `False`    |           | Unmanaged devices to target for the policy rule.  Cannot be set with `managed_device`.                                                     |
 ## Requirements
 
 | Name | Version |
@@ -45,6 +45,8 @@ No modules.
 | [okta_app_signon_policy.this](https://registry.terraform.io/providers/okta/okta/4.12.0/docs/resources/app_signon_policy) | resource |
 | [okta_app_signon_policy_rule.implicit_deny](https://registry.terraform.io/providers/okta/okta/4.12.0/docs/resources/app_signon_policy_rule) | resource |
 | [okta_app_signon_policy_rule.rules](https://registry.terraform.io/providers/okta/okta/4.12.0/docs/resources/app_signon_policy_rule) | resource |
+| [okta_group.groups](https://registry.terraform.io/providers/okta/okta/4.12.0/docs/data-sources/group) | data source |
+| [okta_network_zone.zones](https://registry.terraform.io/providers/okta/okta/4.12.0/docs/data-sources/network_zone) | data source |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,34 @@ locals {
       "type" : "DESKTOP"
     }
   }
+
+  network_zones = flatten([
+    for rule in local.config.rules : [
+      for zone in lookup(rule, "network_zones", []) : zone
+    ]
+  ])
+  network_zone_map = {
+    for zone in data.okta_network_zone.zones : zone.name => zone.id
+  }
+
+  groups = flatten([
+    for rule in local.config.rules : [
+      for group in concat(lookup(rule, "group_targets", []), lookup(rule, "group_exclusions", [])) : group
+    ]
+  ])
+  group_map = {
+    for group in data.okta_group.groups : group.name => group.id
+  }
+}
+
+data "okta_network_zone" "zones" {
+  for_each = toset(local.network_zones)
+  name     = each.value
+}
+
+data "okta_group" "groups" {
+  for_each = toset(local.groups)
+  name     = each.value
 }
 
 resource "okta_app_signon_policy" "this" {
@@ -41,12 +69,12 @@ resource "okta_app_signon_policy_rule" "rules" {
   name                        = each.value.name
   access                      = each.value.access
   network_connection          = lookup(each.value, "network_zones", null) != null ? "ZONE" : null
-  network_includes            = lookup(each.value, "network_zones", null)
+  network_includes            = lookup(each.value, "network_zones", null) != null ? [for zone in each.value.network_zones : local.network_zone_map[zone]] : null
   priority                    = each.key
   factor_mode                 = "2FA"
   re_authentication_frequency = lookup(each.value, "step_up_auth", null) != null ? "PT0S" : lookup(each.value, "auth_frequency", null) != null ? local.auth_frequency_map[each.value.auth_frequency] : null
-  groups_included             = lookup(each.value, "group_targets", null)
-  groups_excluded             = lookup(each.value, "group_exclusions", null)
+  groups_included             = lookup(each.value, "group_targets", null) != null ? [for group in each.value.group_targets : local.group_map[group]] : null
+  groups_excluded             = lookup(each.value, "group_exclusions", null) != null ? [for group in each.value.group_exclusions : local.group_map[group]] : null
   device_is_registered        = lookup(each.value, "managed_device", null) != null ? true : null
   device_is_managed           = lookup(each.value, "managed_device", null) != null ? true : null
   dynamic "platform_include" {

--- a/schema.py
+++ b/schema.py
@@ -7,7 +7,8 @@ class Rule(BaseModel):
     name: str = Field(description="Name of the rule")
     access: typing.Literal["ALLOW", "DENY"] = Field(description="Access type.")
     network_zones: typing.Optional[list[str]] = Field(
-        None, description="List of network zone IDs."
+        None,
+        description="List of network zone names.  These must exist.  Consider using `depends_on` in your module declaration on required network zones.",
     )
     step_up_auth: typing.Optional[bool] = Field(
         None, description="Whether or not MFA is required each auth."
@@ -16,10 +17,12 @@ class Rule(BaseModel):
         None, description="Frequency of auth."
     )
     group_targets: typing.Optional[list[str]] = Field(
-        None, description="Groups to target for the policy rule."
+        None,
+        description="Group names to target for the policy rule.  These must exist.  Consider using `depends_on` in your module declaration on required groups.",
     )
     group_exclusions: typing.Optional[list[str]] = Field(
-        None, description="Groups to exclude for the policy rule."
+        None,
+        description="Group names to exclude for the policy rule.  These must exist.  Consider using `depends_on` in your module declaration on required groups.",
     )
     managed_device: typing.Optional[
         list[typing.Literal["all", "ios", "macos", "android", "windows", "chromeos"]]


### PR DESCRIPTION
Allow users to specify names of groups and network zones, rather than opaque IDs by leveraging the network zone and group data sources provided by Okta.